### PR TITLE
Added support for paths in @vueComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,24 @@ Then add the ServiceProvider to your `config/app.php` file:
 
 Super lighteweight documentation below. Please let us know if there's something more descriptive you needed.
 
-#### `@vueComponent(<component-path>)`
+#### `@vueComponent(<component-name>, <optional path>)`
 
 Blade Directive for rendering our Vue Components. 
 
-**component-path** is currently a filename for a blade component. Does not support subfolders at this time.
+**component-name** file name of the component to be rendered.
+
+**path** optionally provide a path to the component if nested in a subfolder.
 
 usage example:
 
 ```blade
-@vueComponent(app)
+@vueComponent(App)
 
-this loads resources/views/app.blade.php
+this loads resources/views/App.blade.php
+
+@vueComponent(App, vue/routes)
+
+this loads resources/views/vue/routes/App.blade.php
 ```
 
 Templates loaded via `@vueComponent` will have `$vue` passed to them as a boolean. Additionally, they will be pushed to a [stack](https://laravel.com/docs/5.4/blade#stacks) called `vue`

--- a/src/VueComponentServiceProvider.php
+++ b/src/VueComponentServiceProvider.php
@@ -13,23 +13,34 @@ class VueComponentServiceProvider extends ServiceProvider
          * Will include the PHP output of a BladeVue Component, and push_once the JS template
          * for a Bladevue Component
          *
-         * @string $componentName path to the component to be rendered.
+         * @string $componentName Name of the vue Component/Blade File to be rendered
+         * @string $path can optionally specify a path to the component
          */
-        Blade::directive('vueComponent', function ($componentName) {
-            $pushKey = '__pushonce_vue_'.$componentName;
+        Blade::directive('vueComponent', function ($expression) {
+            // Check if our expression includes a path, and extract it if so
+            if (strpos($expression, ', ') !== false) {
+                list($componentName, $path) = explode(', ', $expression);
+            } else {
+                $componentName = $expression;
+                $path = '';
+            }
+            
+
+            $pushKey = '__pushonce_vue_'.str_slug($componentName);
 
             // pushes (only once!) the vuejs version of this to vue stack
             // makes a view, with the existing view data passed in, and renders it.
             return "<?php
                     if(! isset(\$__env->$pushKey)): \$__env->$pushKey = 1; \$__env->startPush('vue');
                     echo '<script type=\"text/x-template\" id=\"{$componentName}-template\">';
-                    echo \$__env->make('{$componentName}', array_except(get_defined_vars(), ['__data', '__path']))->with(['vue' => true]);
+                    echo \$__env->make('{$path}/{$componentName}', array_except(get_defined_vars(), ['__data', '__path']))->with(['vue' => true]);
                     echo '</script>';
                     \$__env->stopPush(); endif;
 
-                    echo \$__env->make('{$componentName}', array_except(get_defined_vars(), ['__data', '__path']))->with(['vue' => false])->render();
+                    echo \$__env->make('{$path}/{$componentName}', array_except(get_defined_vars(), ['__data', '__path']))->with(['vue' => false])->render();
                 ?>";
         });
+
 
         /**
          * vue Blade Directive


### PR DESCRIPTION
Solves Issue #1 

---

Will now be able to make a component within a path.

`@vueComponent(App)` will load `resources/views/App.blade.php`

`@vueComponent(App, vue/routes)` will load `resources/views/vue/routes/App.blade.php`